### PR TITLE
Remove border from overlay

### DIFF
--- a/Overlay.ios.js
+++ b/Overlay.ios.js
@@ -65,6 +65,7 @@ var styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
+    borderWidth: 0,
     backgroundColor: 'transparent',
   },
 })


### PR DESCRIPTION
I'm using this in a project and after upgrading both react and this library I noticed a red border around the overlay whenever it appeared. Seems that adding this css fixes the problem.
