### PR TITLE
peerDependencies updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "RNOverlayManager.m"
   ],
   "peerDependencies": {
-    "react-native": ">= 0.4.2"
+    "react-native": ">=0.4.2 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The peerDependencies were outdated causing a EPEERINVALID error on npm.
I added the new versions of react-native.
Is it okay or would you prefer to just remove the peerDependencies property, that way we wouldn't have to update it on every react-native release...
