### PR TITLE
fixbug: The app will crash when the subviews of rootView is empty

### DIFF
--- a/RNClickThroughWindow.m
+++ b/RNClickThroughWindow.m
@@ -5,14 +5,17 @@
 @implementation RNClickThroughWindow
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
-  UIView *rootView = [[[[self rootViewController] view] subviews] objectAtIndex:0];
-  CGPoint hitPoint = [rootView convertPoint:point fromView:self];
-
-  if ([rootView pointInside:hitPoint withEvent:event]) {
-    return [super hitTest:point withEvent:event];
-  } else {
-    return nil;
+  NSArray *subviews = [[[self rootViewController] view] subviews];
+    
+  if ([subviews count] > 0) {
+    UIView *rootView = [subviews objectAtIndex:0];
+    CGPoint hitPoint = [rootView convertPoint:point fromView:self];
+    
+    if ([rootView pointInside:hitPoint withEvent:event]) {
+        return [super hitTest:point withEvent:event];
+    }      
   }
+  
+  return nil;
 }
-
 @end


### PR DESCRIPTION
```
Exception Type:  EXC_CRASH (SIGABRT)
Exception Codes: 0x0000000000000000, 0x0000000000000000
Exception Note:  EXC_CORPSE_NOTIFY
Triggered by Thread:  0

Filtered syslog:
None found

Last Exception Backtrace:
0   CoreFoundation                  0x1839b8f5c __exceptionPreprocess + 124
1   libobjc.A.dylib                 0x1985aff80 objc_exception_throw + 56
2   CoreFoundation                  0x183934b60 -[__NSArray0 objectAtIndex:] + 112
3   qianlonglaile                   0x10002f098 -[RNClickThroughWindow hitTest:withEvent:] (RNClickThroughWindow.m:8)
4   UIKit                           0x189210c8c -[UIView(Geometry) _hitTest:withEvent:windowServerHitTestWindow:] + 92
5   UIKit                           0x189200724 __70+[UIWindow _hitTestToPoint:forEvent:windowServerHitTestWindow:screen:]_block_invoke + 
```
