### PR TITLE
Fix for upgrading to React Native 25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ DerivedData
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
 #Pods/
+
+.DS_Store

--- a/Overlay.ios.js
+++ b/Overlay.ios.js
@@ -5,13 +5,14 @@
 
 'use strict';
 
-var React = require('react-native');
+var ReactNative = require('react-native');
+var React = require('react');
+
 var {
   View,
-  PropTypes,
   StyleSheet,
   requireNativeComponent,
-} = React;
+} = ReactNative;
 
 type Props = {
   isVisible: boolean;


### PR DESCRIPTION
React Native 0.25 needs React to required from 'react' instead of 'react-native'.
